### PR TITLE
fix: error while counting attachment when attachment is null

### DIFF
--- a/src/Livewire/ChatBox.php
+++ b/src/Livewire/ChatBox.php
@@ -147,7 +147,7 @@ class ChatBox extends Component implements HasForms
                             return false;
                         })
                         ->required(function (Get $get) {
-                            if (count($get('attachments')) > 0) {
+                            if (is_array($get('attachments')) && count($get('attachments')) > 0) {
                                 return false;
                             }
 


### PR DESCRIPTION
fix error: count(): Argument #1 ($value) must be of type Countable|array, null given