### PR TITLE
Show/Hide Menu Item From Navgation

### DIFF
--- a/config/filachat.php
+++ b/config/filachat.php
@@ -19,9 +19,9 @@ return [
     | Show menu item
     |--------------------------------------------------------------------------
     |
-    | This option controls whether roles (user, agent) are used in the chat
-    | system. If disabled, all users can chat with each other without role
-    | constraints.
+    | This option controls whether this plugin registers a menu item in the
+    | sidebar. If disabled, you can manually register a navigation item in a
+    | different part of the panel.
     |
     */
     'show_in_menu' => true,

--- a/config/filachat.php
+++ b/config/filachat.php
@@ -16,6 +16,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Show menu item
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether roles (user, agent) are used in the chat
+    | system. If disabled, all users can chat with each other without role
+    | constraints.
+    |
+    */
+    'show_in_menu' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | User Model
     |--------------------------------------------------------------------------
     |

--- a/src/Pages/FilaChat.php
+++ b/src/Pages/FilaChat.php
@@ -20,6 +20,11 @@ class FilaChat extends Page
         return config('filachat.slug') . '/{id?}';
     }
 
+    public static function shouldRegisterNavigation(): bool
+    {
+        return config('filachat.show_in_menu', true);
+    }
+
     public static function getNavigationLabel(): string
     {
         return __(config('filachat.navigation_label'));


### PR DESCRIPTION
For edge cases where the developer might want the chat icon on a different part of the screen (e.g topbar or user menu) instead of the sidebar. 

This PR  allows the user to configure whether to show the menu item in the sidebar or not (default is true). 

User can then optionally set to false and register the link elsewhere by themselves.